### PR TITLE
fix: close opened fds

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -133,6 +133,9 @@ impl Shmap {
             // If the value is empty, remove it and return None
             drop(guard);
             let _ = self._remove(sanitized_key);
+            unsafe {
+                libc::close(fd);
+            }
             return Ok(None);
         }
 
@@ -143,7 +146,9 @@ impl Shmap {
         } else {
             mmap.to_vec()
         };
-
+        unsafe {
+            libc::close(fd);
+        }
         Ok(Some(bytes))
     }
 
@@ -218,6 +223,9 @@ impl Shmap {
             let fd = shm_open_write(sanitized_key, bytes.len())?;
             let mut mmap = unsafe { MmapMut::map_mut(fd) }?;
             mmap.copy_from_slice(bytes.as_slice());
+            unsafe {
+                libc::close(fd);
+            }
             Ok(())
         }() {
             Ok(_) => Ok(()),

--- a/src/map.rs
+++ b/src/map.rs
@@ -133,9 +133,6 @@ impl Shmap {
             // If the value is empty, remove it and return None
             drop(guard);
             let _ = self._remove(sanitized_key);
-            unsafe {
-                libc::close(fd);
-            }
             return Ok(None);
         }
 
@@ -146,9 +143,6 @@ impl Shmap {
         } else {
             mmap.to_vec()
         };
-        unsafe {
-            libc::close(fd);
-        }
         Ok(Some(bytes))
     }
 
@@ -223,9 +217,6 @@ impl Shmap {
             let fd = shm_open_write(sanitized_key, bytes.len())?;
             let mut mmap = unsafe { MmapMut::map_mut(fd) }?;
             mmap.copy_from_slice(bytes.as_slice());
-            unsafe {
-                libc::close(fd);
-            }
             Ok(())
         }() {
             Ok(_) => Ok(()),

--- a/src/tests/map.rs
+++ b/src/tests/map.rs
@@ -195,6 +195,30 @@ fn test_expiration() {
     let _: String = shmap.get(&key).unwrap().unwrap();
 }
 
+#[test]
+fn test_many_fd() {
+    let shmap = Shmap::new();
+
+    // set fd limit to 42 for testing purpose
+    unsafe {
+        let rlim: libc::rlimit = libc::rlimit {
+            rlim_cur: 42,
+            rlim_max: 42,
+        };
+        if libc::setrlimit(libc::RLIMIT_NOFILE, &rlim) != 0 {
+            let err = std::io::Error::last_os_error();
+            panic!("raise_fd_limit: error calling setrlimit: {}", err);
+        }
+    }
+
+    for i in 0..50 {
+        let key = rand_string(i);
+        shmap.insert(&key, "0").unwrap();
+    }
+
+    fdlimit::raise_fd_limit();
+}
+
 // test concurrency between set
 #[test]
 fn test_set_concurrency() {


### PR DESCRIPTION
It's an attempt to fix #1 in a naive way.
From what I understand from Mmap documentation I close the fd after data are copied so it should not be an issue.
In my use case it works fine and number of open files keeps reasonnable 